### PR TITLE
tidy/lib.py: LIBNAMES: Add html tidy v5.8

### DIFF
--- a/tidy/lib.py
+++ b/tidy/lib.py
@@ -22,6 +22,8 @@ LIBNAMES = (
     "libtidy-0.99.so.0.0.0",
     # HTML tidy
     "libtidy.so.5",
+    # Linux, HTML tidy v5.8
+    "libtidy.so.58",
     # Debian changed soname
     "libtidy.so.5deb1",
     # Windows?


### PR DESCRIPTION
With HTML tidy v5.8, the upstream SONAME is changed into "58":

>./usr/lib/x86_64-linux-gnu/libtidy.so.58 -> libtidy.so.5.8.0

Adding "libtidy.so.58" into search list to incorporate this change.

Current utidylib source code is not 100% compatible with tidy-html5 v5.8.0. I guess more changes are needed.