### PR TITLE
add the ability to get tidy lib from environment variable

### DIFF
--- a/tidy/lib.py
+++ b/tidy/lib.py
@@ -48,6 +48,10 @@ class Loader:
         )
 
         # Try loading library
+        lib_path = os.environ.get("TIDY_LIBRARY_FULL_PATH")
+        if lib_path:
+            self.libnames = (lib_path,) + self.libnames
+
         for libname in self.libnames:
             try:
                 self.lib = ctypes.CDLL(libname)

--- a/tidy/lib.py
+++ b/tidy/lib.py
@@ -47,11 +47,12 @@ class Loader:
             (os.path.dirname(__file__), os.pathsep, os.environ["PATH"])
         )
 
-        # Try loading library
+        # Add full path to a library
         lib_path = os.environ.get("TIDY_LIBRARY_FULL_PATH")
         if lib_path:
             self.libnames = (lib_path,) + self.libnames
 
+        # Try loading library
         for libname in self.libnames:
             try:
                 self.lib = ctypes.CDLL(libname)

--- a/tidy/test_tidy.py
+++ b/tidy/test_tidy.py
@@ -115,3 +115,22 @@ class TidyTestCase(unittest.TestCase):
     def test_missing_load(self):
         with self.assertRaises(OSError):
             tidy.lib.Loader(libnames=("not-existing-library",))
+
+    def test_lib_from_environ(self):
+        os.environ["TIDY_LIBRARY_FULL_PATH"] = "/foo/bar/tidy"
+        loader = tidy.lib.Loader()
+        expected_libnames = (
+            "/foo/bar/tidy",
+            "libtidy.so",
+            "libtidy.dylib",
+            "tidy",
+            "cygtidy-0-99-0",
+            "libtidy-0.99.so.0",
+            "libtidy-0.99.so.0.0.0",
+            "libtidy.so.5",
+            "libtidy.so.58",
+            "libtidy.so.5deb1",
+            "libtidy",
+            "tidylib",
+        )
+        self.assertEqual(loader.libnames, expected_libnames)


### PR DESCRIPTION
On my mac (osx has its own tidy version) I installed tidy-html5 via homebrew to get a newer version, but uTidylib uses the OSX version even if I set the homebrew path before the system path. So it would be nice if we can implement it and add a new release.