### PR TITLE
Add typehints and code improvements across the board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .coverage
 /.cache/
 /.pytest_cache/
+/.idea/

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,2 +1,2 @@
-pre-commit==3.6.2
+pre-commit==3.5.0
 twine

--- a/tidy/error.py
+++ b/tidy/error.py
@@ -18,7 +18,7 @@ class InvalidOptionError(TidyLibError):
     Exception for invalid option.
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "%s was not a valid Tidy option." % (self.args[0])
 
 

--- a/tidy/lib.py
+++ b/tidy/lib.py
@@ -111,7 +111,7 @@ class ReportItem:
     :attribute severity: D, W, E or C indicating severity
     :attribute line: Line where error was fired (can be None)
     :attribute col: Column where error was fired (can be None)
-    :attribute message: Error message itsef
+    :attribute message: Error message itself
     :attribute err: Whole error message as returned by tidy
     """
 
@@ -214,6 +214,8 @@ class Document:
             # this will flush out most argument type errors...
             if value is None:
                 value = ""
+            if isinstance(value, bool):
+                value = int(value)
 
             _tidy.OptParseValue(
                 self.cdoc,
@@ -269,7 +271,6 @@ class Document:
 
     def __str__(self) -> str:
         return self.gettext()
-        return self.getvalue()
 
 
 ERROR_MAP = {
@@ -326,9 +327,11 @@ class DocumentFactory(FactoryDict[weakref.ReferenceType, Document]):
         Use text as an HTML file, and process it, returning a
         document object.
         """
-        doc = self._create(**kwargs)
+        doc = self.create(**kwargs)
         if isinstance(text, str):
-            text = text.encode(doc.options["input_encoding"])
+            input_encoding = doc.options["input_encoding"]
+            assert isinstance(input_encoding, str)
+            text = text.encode(input_encoding)
         self.loadString(doc, text)
         return doc
 

--- a/tidy/lib.py
+++ b/tidy/lib.py
@@ -4,7 +4,18 @@ import os
 import os.path
 import weakref
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Union, Optional, Tuple, Callable, BinaryIO, Mapping, TypeVar
+from typing import (
+    Any,
+    BinaryIO,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from tidy.error import InvalidOptionError, OptionArgError
 
@@ -281,7 +292,9 @@ ERROR_MAP = {
 
 class DocumentFactory(FactoryDict[weakref.ReferenceType, Document]):
     @staticmethod
-    def load(doc: Document, arg: bytes, loader: Callable[[Document, bytes], int]) -> None:
+    def load(
+        doc: Document, arg: bytes, loader: Callable[[Document, bytes], int]
+    ) -> None:
         status = loader(doc.cdoc, arg)
         if status > 0:
             _tidy.CleanAndRepair(doc.cdoc)

--- a/tidy/test_tidy.py
+++ b/tidy/test_tidy.py
@@ -132,3 +132,7 @@ class TidyTestCase(unittest.TestCase):
             "tidylib",
         )
         self.assertEqual(loader.libnames, expected_libnames)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tidy/test_tidy.py
+++ b/tidy/test_tidy.py
@@ -67,11 +67,11 @@ class TidyTestCase(unittest.TestCase):
 
     def test_options(self):
         doc1 = tidy.parseString(
-            self.input1, add_xml_decl=1, show_errors=1, newline="CR", output_xhtml=1
+            self.input1, add_xml_decl=1, show_errors=1, newline="CR", output_xhtml=True
         )
         self.assertIn("CDATA", str(doc1))
         doc2 = tidy.parseString(
-            "<Html>", add_xml_decl=1, show_errors=1, newline="CR", output_xhtml=1
+            "<Html>", add_xml_decl=1, show_errors=1, newline="CR", output_xhtml=True
         )
         self.assertTrue(str(doc2).startswith("<?xml"))
         self.assertFalse(len(doc2.errors) == 0)
@@ -133,6 +133,9 @@ class TidyTestCase(unittest.TestCase):
             "tidylib",
         )
         self.assertEqual(loader.libnames, expected_libnames)
+
+    def test_lib_version(self):
+        self.assertEqual(len(tidy.lib.getTidyVersion().split(".")), 3)
 
 
 if __name__ == "__main__":

--- a/tidy/test_tidy.py
+++ b/tidy/test_tidy.py
@@ -1,7 +1,7 @@
 import io
 import os
-import unittest
 import pathlib
+import unittest
 
 import tidy
 import tidy.lib
@@ -38,7 +38,8 @@ class TidyTestCase(unittest.TestCase):
 
     def test_encodings(self):
         text = (
-            pathlib.Path(self.test_file).read_bytes()
+            pathlib.Path(self.test_file)
+            .read_bytes()
             .decode("utf8")
             .encode("ascii", "xmlcharrefreplace")
         )

--- a/tidy/test_tidy.py
+++ b/tidy/test_tidy.py
@@ -1,6 +1,7 @@
 import io
 import os
 import unittest
+import pathlib
 
 import tidy
 import tidy.lib
@@ -37,8 +38,7 @@ class TidyTestCase(unittest.TestCase):
 
     def test_encodings(self):
         text = (
-            open(self.test_file, "rb")
-            .read()
+            pathlib.Path(self.test_file).read_bytes()
             .decode("utf8")
             .encode("ascii", "xmlcharrefreplace")
         )


### PR DESCRIPTION
- Removed file descriptor leak in tests
- Added typehints across the library
- Almost `mypy --strict` compatible; would need drop of Python 3.8 compatibility to reach that; decided against that
- Removed unreachable code
- Added support for `bool` as option argument
- Small spelling correction
- Added `py.typed` marker file for `mypy`