### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/nijel/utidylib/security/code-scanning/1](https://github.com/nijel/utidylib/security/code-scanning/1)

To fix this issue, we should add a `permissions` block that limits the workflow's permissions to only what it needs. The best practice is to add the least permissive `permissions` block—typically `contents: read`—unless the jobs require more. Since nothing in the provided workflow appears to need additional access, `contents: read` is appropriate.

You can add the `permissions:` key either at the root of the workflow (to apply to all jobs) or within the individual job. For clarity and future extensibility, it's preferred to add the block at the root-level (after the `name:` or `on:` blocks), ensuring the least privilege is applied to all jobs by default.

**Where to change:**  
- File: `.github/workflows/test.yml`
- Insert:
  - `permissions:`
  - Indented `contents: read`
- Placement:
  - Immediately after the `name:` or `on:` block (commonly after `on:` for clarity and convention), before `jobs:`.

**What is needed:**  
- Add the `permissions:` block as described above.  
- No migrations, imports, or functional code changes required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
